### PR TITLE
[FEAT] JWT Util class 개발

### DIFF
--- a/SideProject/build.gradle.kts
+++ b/SideProject/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 kotlin {

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/JwtProperties.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/JwtProperties.kt
@@ -1,0 +1,14 @@
+package com.example.sideproject.infra.security.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+data class JwtProperties(
+    @Value("\${jwt.secret}")
+    val secret: String,
+    @Value("\${jwt.access-token.expiration-time}")
+    val accessTokenExpirationTime: Long,
+    @Value("\${jwt.refresh-token.expiration-time}")
+    val refreshTokenExpirationTime: Long
+)

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
@@ -6,17 +6,15 @@ import java.util.*
 
 interface JwtUtil {
 
-    fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign : Boolean)
+    fun generateAccessToken(uuid: UUID) : String
 
-    fun generateRefreshToken(uuid : UUID, expirationMillis: Long)
+    fun generateRefreshToken(uuid : UUID) : String
 
-    fun getTokenFromHeader(httpServletRequest: HttpServletRequest)
+    fun getTokenFromHeader(httpServletRequest: HttpServletRequest): String
 
-    fun getUserIdFromToken(token: String?): String
+    fun getUserIdFromToken(token: String): String
 
-    fun getClaimsFromToken(token : String?) : Claims
 
-    fun validateToken(token : String)
 
     fun signCheck(token : String) :Boolean
 }

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
@@ -1,0 +1,23 @@
+package com.example.sideproject.infra.security.jwt
+
+import io.jsonwebtoken.Claims
+import jakarta.servlet.http.HttpServletRequest
+import java.util.*
+
+interface JwtUtil {
+
+    fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign : Boolean)
+
+    fun generateRefreshToken(uuid : UUID, expirationMillis: Long)
+
+    fun getTokenFromHeader(httpServletRequest: HttpServletRequest)
+
+    fun getUserIdFromToken(token: String?): String
+
+    fun getClaimsFromToken(token : String?) : Claims
+
+    fun validateToken(token : String)
+
+    fun signCheck(token : String) :Boolean
+}
+

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
@@ -1,0 +1,4 @@
+package com.example.sideproject.infra.security.jwt
+
+class JwtUtil {
+}

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
@@ -1,4 +1,12 @@
 package com.example.sideproject.infra.security.jwt
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
 class JwtUtil {
+    var log : Logger = LoggerFactory.getLogger(this::class.java)
+
+
 }

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -4,12 +4,28 @@ import io.jsonwebtoken.Claims
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class JwtUtilImpl() : JwtUtil {
+class JwtUtilImpl(
+
+    @Value("\${jwt.secret}")
+    val SECRET_KEY : String,
+
+    @Value("\${jwt.access-token.expiration-time}")
+    val ACCESS_TOKEN_EXPIRATION_TIME : Long,
+
+    @Value("\${jwt.refresh-token.expiration-time}")
+    val REFRESH_TOKEN_EXPIRATION_TIME : Long
+
+
+) : JwtUtil {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
+
+
+
     override fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign: Boolean) {
         TODO("Not yet implemented")
     }

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -1,12 +1,15 @@
 package com.example.sideproject.infra.security.jwt
 
 import io.jsonwebtoken.Claims
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.util.*
+import javax.crypto.SecretKey
 
 @Component
 class JwtUtilImpl(
@@ -24,7 +27,10 @@ class JwtUtilImpl(
 ) : JwtUtil {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
-
+    private fun getSigningKey(): SecretKey{
+        val keyBytes = Decoders.BASE64.decode(SECRET_KEY)
+        return Keys.hmacShaKeyFor(keyBytes)
+    }
 
     override fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign: Boolean) {
         TODO("Not yet implemented")

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -1,12 +1,42 @@
 package com.example.sideproject.infra.security.jwt
 
+import io.jsonwebtoken.Claims
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
-class JwtUtilImpl {
+class JwtUtilImpl() : JwtUtil {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
+    override fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun generateRefreshToken(uuid: UUID, expirationMillis: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getTokenFromHeader(httpServletRequest: HttpServletRequest) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUserIdFromToken(token: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getClaimsFromToken(token: String?): Claims {
+        TODO("Not yet implemented")
+    }
+
+    override fun validateToken(token: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun signCheck(token: String): Boolean {
+        TODO("Not yet implemented")
+    }
 
 
 }

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -1,13 +1,16 @@
 package com.example.sideproject.infra.security.jwt
 
-import io.jsonwebtoken.Claims
+import io.jsonwebtoken.*
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
+import org.springframework.util.StringUtils
+import java.security.SignatureException
 import java.util.*
 import javax.crypto.SecretKey
 
@@ -32,28 +35,88 @@ class JwtUtilImpl(
         return Keys.hmacShaKeyFor(keyBytes)
     }
 
-    override fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign: Boolean) {
-        TODO("Not yet implemented")
+    //TODO("이후 회원가입 여부 확인도 Token에 추가")
+    override fun generateAccessToken(uuid: UUID) : String{
+        log.info("액세스 토큰 발행.")
+        return Jwts.builder()
+            .claim("userId", uuid.toString())// 클레임에 userId 추가
+            .setIssuedAt(Date())
+            .setExpiration(Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_TIME))
+            .signWith(getSigningKey())
+            .compact()
     }
 
-    override fun generateRefreshToken(uuid: UUID, expirationMillis: Long) {
-        TODO("Not yet implemented")
+
+    //TODO("이후 claim에서 userId 제거")
+    //TODO("레디스를 도입한다면 JWT 방식의 R.T를 UUID 식으로 변경하면 어떨까?")
+        //레디스를 활용하면 TTL로 유효기간이 지난 Token을 자동 삭제할 수 있음으로
+        //JWT를 꼭 사용하지 않아도 되지 않을까 싶음.
+    override fun generateRefreshToken(uuid: UUID) : String{
+        log.info("리프레쉬 토큰 발행.")
+        return Jwts.builder()
+            .claim("userId", uuid.toString()) // 클레임에 userId 추가
+            .setIssuedAt(Date())
+            .setExpiration(Date(System.currentTimeMillis()))
+            .signWith(getSigningKey())
+            .compact()
     }
 
-    override fun getTokenFromHeader(httpServletRequest: HttpServletRequest) {
-        TODO("Not yet implemented")
+    /**
+     * 헤더에서 AccessToken 추출하기
+     */
+    override fun getTokenFromHeader(httpServletRequest: HttpServletRequest): String {
+        val authorizationHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)
+            //TODO("토큰 없음 Exception 반환")
+            ?: throw Exception()
+        //hasText(token)토큰이 넘어왔는지 확인
+        if(authorizationHeader.startsWith("Bearer ") && authorizationHeader.length > 7)
+            return authorizationHeader.substring(7)
+        else
+            //TODO("Bearer 스킴이 없거나 형식이 잘못된 Authorization 헤더입니다")
+            throw Exception()
     }
 
-    override fun getUserIdFromToken(token: String?): String {
-        TODO("Not yet implemented")
+    //어차피 이 친구만 외부로 들어 내놓고
+    //이후 토큰 검증, 클레임 받아오는 것, userId 빼오는것은 별도로 구성하면 되겠네...?
+    //로직이 헤더 추출 메서드 호출 -> a.t를 포함하여 해당 메소드 호출 -> 검증 메서드 호출(Jwt 반환)-> Claim 반환 메서드 호출 (claim 반환) -> 해당 메서드에서 claim userId 추출 및 반환
+    override fun getUserIdFromToken(token: String): String {
+        val userId: String = getClaimsFromToken(validateToken(token)).get("userId", String::class.java)
+        log.info("유저 id 반환")
+        return userId
     }
 
-    override fun getClaimsFromToken(token: String?): Claims {
-        TODO("Not yet implemented")
+    //claim을 받아올때랑 토큰을 검증할때 결국 같은 로직을 거침 그렇다면 이를 해결하여 중복을 제거해야하는 게 아닐까.
+    //validation 체크를 할 때 JWT를 반환 받아오고, 이를 이후 여기의 매개변수로 보내는 방식
+    private fun getClaimsFromToken(token: Jws<Claims>): Claims {
+        return token.body
     }
 
-    override fun validateToken(token: String) {
-        TODO("Not yet implemented")
+    private fun validateToken(token: String) : Jws<Claims> {
+        //parseClamisJWS에서 발생하는 예외를
+        //본 프로젝트에서의 예외로 변경.
+        return try{
+            Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+        }catch (e : SignatureException){
+            //TODO("토큰 유효하지 않다는 예외 제작")
+            throw Exception()
+        }catch (e : ExpiredJwtException){
+            //TODO("토큰 만료되었다는 예외 제작")
+            throw Exception()
+        }catch (e: JwtException) {
+            // 토큰이 유효하지 않은 경우
+            log.warn("유효하지 않은 토큰입니다.")
+            //TODO(토큰이 유효하지 않는 경우 반환하는 Exception을 만들어 처리)
+            throw Exception()
+        } catch (e: IllegalArgumentException) {
+            log.warn("유효하지 않은 토큰입니다.")
+            //TODO(토큰이 유효하지 않는 경우 반환하는 Exception을 만들어 처리)
+            throw Exception()
+        }catch (e : Exception){
+            throw Exception()
+        }
     }
 
     override fun signCheck(token: String): Boolean {

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -1,5 +1,6 @@
 package com.example.sideproject.infra.security.jwt
 
+import com.example.sideproject.infra.security.config.JwtProperties
 import io.jsonwebtoken.*
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
@@ -16,22 +17,13 @@ import javax.crypto.SecretKey
 
 @Component
 class JwtUtilImpl(
-
-    @Value("\${jwt.secret}")
-    val SECRET_KEY : String,
-
-    @Value("\${jwt.access-token.expiration-time}")
-    val ACCESS_TOKEN_EXPIRATION_TIME : Long,
-
-    @Value("\${jwt.refresh-token.expiration-time}")
-    val REFRESH_TOKEN_EXPIRATION_TIME : Long
-
+    val jwtProperties: JwtProperties
 
 ) : JwtUtil {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
     private fun getSigningKey(): SecretKey{
-        val keyBytes = Decoders.BASE64.decode(SECRET_KEY)
+        val keyBytes = Decoders.BASE64.decode(jwtProperties.secret)
         return Keys.hmacShaKeyFor(keyBytes)
     }
 
@@ -41,7 +33,7 @@ class JwtUtilImpl(
         return Jwts.builder()
             .claim("userId", uuid.toString())// 클레임에 userId 추가
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_TIME))
+            .setExpiration(Date(System.currentTimeMillis() + jwtProperties.accessTokenExpirationTime))
             .signWith(getSigningKey())
             .compact()
     }
@@ -56,7 +48,7 @@ class JwtUtilImpl(
         return Jwts.builder()
             .claim("userId", uuid.toString()) // 클레임에 userId 추가
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis()))
+            .setExpiration(Date(System.currentTimeMillis()+jwtProperties.refreshTokenExpirationTime))
             .signWith(getSigningKey())
             .compact()
     }

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
-class JwtUtil {
+class JwtUtilImpl {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
 


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 작업했는지 간략하게 요약해 주세요.

## 🔗 관련 이슈
- 이 PR이 해결하는 이슈 번호를 명시해 주세요.  
  (머지 시 자동으로 이슈가 닫힙니다)

Closes #48

## ✨ 상세 내용
- 어떤 작업을 했는지 상세히 설명해 주세요.
- 변경된 코드의 주요 로직이나 흐름이 있다면 작성해 주세요.

## 1️⃣ Jwt를 왜 쓰나요?
### ✅ 기존 세션 방식의 문제점

#### 서버에 상태 저장 필요
사용자가 로그인할 때마다 서버가 세션 ID와 사용자 정보를 메모리나 DB에 저장해야 한다.

#### 수평 확장에 불리함
서버가 여러 대일 경우 세션을 공유하거나 동기화(예: Redis 세션 저장소)가 필요하다.

#### 스케일 아웃 시 복잡성 증가
세션 공유를 위해 외부 저장소(Redis, DB 등)를 추가 도입해야 하므로 인프라가 복잡해진다.

#### 무상태 통신 어려움
RESTful 아키텍처의 Stateless 원칙과 충돌되어, 진정한 REST 설계에 방해가 된다.

#### 부하 분산 문제
로드밸런서가 세션을 기억한 서버로만 요청을 전달해야 하는 “세션 스티키네스” 설정이 필요할 수 있다.

<hr>

### ✅ JWT가 해결한 방식

#### 토큰 자체에 정보 포함
서버는 상태를 저장하지 않아도 되며, 클라이언트가 JWT를 통해 인증 정보를 매번 직접 전달한다.

#### Stateless 아키텍처 지원
어떤 서버든 JWT만 검증하면 되므로 서버 간 세션 공유나 상태 동기화가 필요 없다.

#### 수평 확장 용이
서버가 사용자 인증 정보를 기억할 필요가 없으므로 서버 수가 늘어나도 확장이 간편하다.

#### 로드 밸런싱 간편화
세션 유지와 무관하게 모든 서버가 동일하게 요청을 처리할 수 있어 부하 분산이 자유롭다.

#### RESTful 구조에 적합
서버가 상태를 가지지 않기 때문에 무상태성을 강조하는 RESTful API 구조와 잘 맞는다.

## 2️⃣ 어떻게 구현하였나요.

### ✅ 의존성 추가
우선 Java에서 Jwt 를 간편하게 쓰기 위해서는 **JJWT 라는 라이브러리**가 필요합니다.

이 JJWT 라이브러리는 3개의 모듈로 나뉘어 있으며,

#### JJwt
- jjwt-api      : JWT 기능의 핵심 인터페이스와 추상 클래스 제공 (Builder, Parser 등)
- jjwt-impl     : 실제 JWT 생성, 서명, 파싱 등의 로직을 구현한 모듈
- jjwt-jackson  : JWT의 Payload(Claims)를 JSON으로 직렬화/역직렬화하기 위한 Jackson 기반 모듈

위 3가지 모듈의 의존성을 추가합니다.

```
    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")

```

### ✅ JwtUtil 개발

JwtUtil에서 구현되어야하는 기능은
토큰 생성 / 검증 / 추출의 과정입니다.
이를 위해 해당 메소드들이 포함된 interface를 우선 작성해주었습니다.

```
interface JwtUtil {
    //A.T 생성
    fun generateAccessToken(uuid: UUID) : String
    //R.T 생성
    fun generateRefreshToken(uuid : UUID) : String
    //토큰 추출
    fun getTokenFromHeader(httpServletRequest: HttpServletRequest): String
   //토큰 내용 추출
    fun getUserIdFromToken(token: String): String
   //이후 회원가입 로직 생성시 사용
    fun signCheck(token : String) :Boolean
}
```
기존에는 토큰 검증 로직을 별도의 인터페이스로 분리했지만,
검증은 결국 토큰에서 정보를 추출하는 시점에만 수행되므로,
해당 로직을 private 메서드로 캡슐화하고 정보 추출 메서드 내부에 통합하였습니다.








## 📝 작업하며 배운 점 / 고민하는 부분
- 고민 중인 내용으로 현재 R.T의 경우 JWT 방식을 써야하는 가하는 고민에 있습니다.

Refresh Token은 오직 Access Token 재발급을 위한 용도이기 때문에, 실제로는 중요한 정보를 담지 않고, 서명 검증만을 위한 역할을 합니다.
지금은 Redis 같은 TTL 관리 도구가 없어, Refresh Token의 유효성 검사는 JWT의 만료 시간(exp)을 기준으로 하고 있습니다.

그런데 만약 Redis를 도입해 TTL 자동 관리가 가능해진다면,
"Refresh Token도 과연 꼭 JWT 형태여야 할까?" 라는 의문이 들었습니다.

어차피 Refresh Token은 서버(DB)에 저장하고, 재발급 요청 시 해당 토큰이 유효한지 DB나 Redis를 통해 확인한다면,
꼭 JWT일 필요 없이 UUID(128비트 난수)나 SecureToken(256비트 난수) 형태로 발급해도 되지 않을까 싶습니다.

물론 JWT는 서명 검증을 통해 위·변조를 방지할 수 있다는 장점이 있지만,

서명 검증 비용이 발생하고

header.payload.signature 구조로 인해 토큰 길이가 300자 이상으로 커져 네트워크 비용도 그만큼 증가합니다.

반면 UUID나 SecureToken은 추측 가능한 가능성이 아주 약간이라도 존재한다는 보안상의 단점은 있지만,
서명 검증이 필요 없고 짧은 길이 덕분에 성능 면에서는 더 유리한 선택이 될 수도 있습니다.

## ✅ 체크리스트
- [x] JwtToken 생성, 검증 로직 개발

## 📅 작업 완료일
- 2025-06-11
