### PR TITLE
[FIX] PR 피드백 반영

### DIFF
--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/AccessTokenProperties.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/AccessTokenProperties.kt
@@ -1,0 +1,8 @@
+package com.example.sideproject.infra.security.config
+
+class AccessTokenProperties {
+
+    lateinit var secret : String
+
+    var expirationTime : Long = 0L
+}

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/JwtProperties.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/JwtProperties.kt
@@ -1,14 +1,14 @@
 package com.example.sideproject.infra.security.config
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-data class JwtProperties(
-    @Value("\${jwt.secret}")
-    val secret: String,
-    @Value("\${jwt.access-token.expiration-time}")
-    val accessTokenExpirationTime: Long,
-    @Value("\${jwt.refresh-token.expiration-time}")
-    val refreshTokenExpirationTime: Long
-)
+@ConfigurationProperties(prefix = "jwt")
+class JwtProperties{
+
+    //NOTE("AccessToken과 RefreshToken의 시크릿 분리")
+    lateinit var accessToken : AccessTokenProperties
+    lateinit var refreshToken : ResfreshTokenProperties
+}

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/ResfreshTokenProperties.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/config/ResfreshTokenProperties.kt
@@ -1,0 +1,7 @@
+package com.example.sideproject.infra.security.config
+
+class ResfreshTokenProperties {
+    lateinit var secret : String
+
+    var expirationTime : Long = 0L
+}

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtil.kt
@@ -1,6 +1,6 @@
 package com.example.sideproject.infra.security.jwt
 
-import io.jsonwebtoken.Claims
+
 import jakarta.servlet.http.HttpServletRequest
 import java.util.*
 
@@ -12,10 +12,9 @@ interface JwtUtil {
 
     fun getTokenFromHeader(httpServletRequest: HttpServletRequest): String
 
-    fun getUserIdFromToken(token: String): String
-
-
+    fun getUserIdFromToken(token: String, isAccess: Boolean): String
 
     fun signCheck(token : String) :Boolean
+
 }
 

--- a/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
+++ b/SideProject/src/main/kotlin/com/example/sideproject/infra/security/jwt/JwtUtilImpl.kt
@@ -7,10 +7,8 @@ import io.jsonwebtoken.security.Keys
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
-import org.springframework.util.StringUtils
 import java.security.SignatureException
 import java.util.*
 import javax.crypto.SecretKey
@@ -18,12 +16,13 @@ import javax.crypto.SecretKey
 @Component
 class JwtUtilImpl(
     val jwtProperties: JwtProperties
-
 ) : JwtUtil {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
-    private fun getSigningKey(): SecretKey{
-        val keyBytes = Decoders.BASE64.decode(jwtProperties.secret)
+    private fun getSigningKey(isAccess : Boolean): SecretKey{
+
+        val secret = if(isAccess) jwtProperties.accessToken.secret else jwtProperties.refreshToken.secret
+        val keyBytes = Decoders.BASE64.decode(secret)
         return Keys.hmacShaKeyFor(keyBytes)
     }
 
@@ -33,8 +32,9 @@ class JwtUtilImpl(
         return Jwts.builder()
             .claim("userId", uuid.toString())// 클레임에 userId 추가
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis() + jwtProperties.accessTokenExpirationTime))
-            .signWith(getSigningKey())
+            .setExpiration(Date(System.currentTimeMillis() + jwtProperties.accessToken.expirationTime))
+            //NODE("수정 사항 isAccess를 통한 시크릿 다르게 적용하기")
+            .signWith(getSigningKey(true))
             .compact()
     }
 
@@ -48,8 +48,9 @@ class JwtUtilImpl(
         return Jwts.builder()
             .claim("userId", uuid.toString()) // 클레임에 userId 추가
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis()+jwtProperties.refreshTokenExpirationTime))
-            .signWith(getSigningKey())
+            .setExpiration(Date(System.currentTimeMillis()+jwtProperties.refreshToken.expirationTime))
+            //NODE("수정 사항 isAccess를 통한 시크릿 다르게 검증하기")
+            .signWith(getSigningKey(false))
             .compact()
     }
 
@@ -68,11 +69,16 @@ class JwtUtilImpl(
             throw Exception()
     }
 
+
     //어차피 이 친구만 외부로 들어 내놓고
     //이후 토큰 검증, 클레임 받아오는 것, userId 빼오는것은 별도로 구성하면 되겠네...?
     //로직이 헤더 추출 메서드 호출 -> a.t를 포함하여 해당 메소드 호출 -> 검증 메서드 호출(Jwt 반환)-> Claim 반환 메서드 호출 (claim 반환) -> 해당 메서드에서 claim userId 추출 및 반환
-    override fun getUserIdFromToken(token: String): String {
-        val userId: String = getClaimsFromToken(validateToken(token)).get("userId", String::class.java)
+    override fun getUserIdFromToken(token: String, isAccess: Boolean): String {
+        //TODO("이후 R.T 에서 userId를 제거하게 된다면 isAccess는 true 고정")
+        //NOTE("수정 사항 isAccess를 통한 시크릿 다르게 검증하기")
+            //NOTE("각 함수의 사용시점(재발행 시 R.T 검증 로직일 땐 isAccess를 false, filter 단에서 A.T 검증일땐 true 하는 식")
+            //이런 식으로 매개변수를 구분하는 것이 좋을 지  아니면 아예 메소드를 나누는게 좋을지 고민이네요!
+        val userId: String = getClaimsFromToken(validateToken(token, isAccess)).get("userId", String::class.java)
         log.info("유저 id 반환")
         return userId
     }
@@ -83,12 +89,15 @@ class JwtUtilImpl(
         return token.body
     }
 
-    private fun validateToken(token: String) : Jws<Claims> {
+    //TODO("이후 R.T 에서 userId를 제거하게 된다면 isAccess 매개변수를 없애고 true로 고정")
+
+    private fun validateToken(token: String, isAccess: Boolean) : Jws<Claims> {
         //parseClamisJWS에서 발생하는 예외를
         //본 프로젝트에서의 예외로 변경.
         return try{
             Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
+                //NOTE("isAccess를 통한 검증할 때 이용하는 시크릿 분리")
+                .setSigningKey(getSigningKey(isAccess))
                 .build()
                 .parseClaimsJws(token)
         }catch (e : SignatureException){

--- a/SideProject/src/test/kotlin/com/example/sideproject/jwt/JwtUtilImplTest.kt
+++ b/SideProject/src/test/kotlin/com/example/sideproject/jwt/JwtUtilImplTest.kt
@@ -1,0 +1,57 @@
+package com.example.sideproject.jwt
+
+import com.example.sideproject.infra.security.config.JwtProperties
+import com.example.sideproject.infra.security.jwt.JwtUtil
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.*
+
+@SpringBootTest
+class JwtUtilImplTest @Autowired constructor(
+    private val jwtUtil: JwtUtil,
+    private val jwtProperties: JwtProperties
+) {
+
+    private val testUserId: UUID = UUID.randomUUID()
+
+    @Test
+    fun `AccessToken 사용처에 AccessToken 사용 - 기대값 성공`() {
+        val accessToken = jwtUtil.generateAccessToken(testUserId)
+        val userId = jwtUtil.getUserIdFromToken(accessToken, isAccess = true)
+        assertEquals(testUserId.toString(), userId)
+    }
+
+    @Test
+    fun `RefreshToken 사용처에 RefreshToken 사용 - 기대값 성공`() {
+        val refreshToken = jwtUtil.generateRefreshToken(testUserId)
+        val userId = jwtUtil.getUserIdFromToken(refreshToken, isAccess = false)
+        assertEquals(testUserId.toString(), userId)
+    }
+
+    @Test
+    fun `RefreshToken 사용처에 AccessToken 사용 - 기대값 실패`() {
+        val accessToken = jwtUtil.generateAccessToken(testUserId)
+        assertThatThrownBy {
+            jwtUtil.getUserIdFromToken(accessToken, isAccess = false)
+        }.isInstanceOf(Exception::class.java) // TODO: CustomException으로 변경 시 그걸로
+    }
+
+    @Test
+    fun `AccessToken 사용처에 RefreshToken 사용 - 기대값 실패 `() {
+        val refreshToken = jwtUtil.generateRefreshToken(testUserId)
+        assertThatThrownBy {
+            jwtUtil.getUserIdFromToken(refreshToken, isAccess = true)
+        }.isInstanceOf(Exception::class.java)
+    }
+
+    @Test
+    fun `AccessToken 사용처에 AccessToken을 사용하 - 기대값을 실패할경우 - 테스트 결과는 실패해야함`() {
+        val accessToken = jwtUtil.generateAccessToken(testUserId)
+        assertThatThrownBy {
+            jwtUtil.getUserIdFromToken(accessToken, isAccess = true)
+        }.isInstanceOf(Exception::class.java) // TODO: CustomException으로 변경 시 그걸로
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 작업했는지 간략하게 요약해 주세요.

## 🔗 관련 이슈
- 이 PR이 해결하는 이슈 번호를 명시해 주세요.  
  (머지 시 자동으로 이슈가 닫힙니다)

Closes #48 

## ✨ 상세 내용
- 어떤 작업을 했는지 상세히 설명해 주세요.
- 변경된 코드의 주요 로직이나 흐름이 있다면 작성해 주세요.

## 1️⃣ ConfigurationProperties 애너테이션 사용

@ConfigurationProperties 애너테이션만으로는 해당 클래스가 빈으로 등록되지 않기 때문에,
빈 등록을 위해 다음 중 하나의 방식이 필요합니다:
- @Component를 직접 명시하거나
- @Configuration을 사용하거나
- 별도로 사용하는 클래스에서 @EnableConfigurationProperties(JwtProperties::class)를 명시하는 방식입니다.

이 중, 해당 클래스가 설정 정보를 담는 구성 클래스임을 명확히 드러내기 위해 @Configuration을 사용하기로 결정하였습니다.

## 2️⃣ ATK RTK SecretKey 분리
이전 PR에서 AccessToken과 RefreshToken을 혼용할 수 있지 않느냐는 의견을 보고, 타당하다고 판단해 이를 반영해보았습니다.

제안해주신 JWT에 Claim을 추가하여 ATK와 RTK를 구분하는 방식 대신,
두 토큰에 서로 다른 SecretKey를 사용하는 방법을 구상해보았습니다.

Claim 없이 SecretKey를 분리한 이유는,

ATK를 RTK로 사용하거나

RTK를 ATK로 사용하는 경우에도

별도의 Claim 검증 없이 서명 단계에서 유효하지 않은 토큰으로 판단할 수 있어,
보다 간결하게 구분할 수 있을 것이라고 생각했기 때문입니다.

다만, 토큰 혼용 시 상황을 명확히 로깅하거나, 구체적인 예외 메시지를 반환해야 하는 요구가 있는 경우에는
Claim을 활용하는 방식이 오히려 더 직관적이고 유리할 수 있을 것 같습니다!

현재 구현된 방식은,
토큰 검증 시 매개변수로 ATK인지 RTK인지 여부를 전달받아 처리하고 있지만,
책임을 더 명확히 분리하기 위해 검증 메서드를 AccessToken용과 RefreshToken용으로 각각 분리하면

이후 R.T 를 JWT에서 UUID로 변경하거나 할 때 좀더 유연하게 코드를 수정할 수 있지 않을까 싶습니다!

## 📝 작업하며 배운 점 / 고민한 부분
- 구현 중 새로 알게 된 점, 고민했던 점을 정리해 주세요.
- 추후 리팩토링이나 개선이 필요한 부분이 있다면 함께 작성해 주세요.


- JWT 도 JWS 와 JWE가 있다는 것
- ATK와 RTK의 구분이 되어야한다는 것

## ✅ 체크리스트

## 📅 작업 완료일
- 2025-06-13
